### PR TITLE
spread this.props.plugins into mdEditor plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export default (opt: { [string]: any } = {}) => {
     opt
   );
 
-  const plugins = [
+  const mdEditorPlugins = [
     MarkdownPlugin(options.markdownOption),
     EditPrism(options.prismOption),
     PluginEditCode(options.codeOption),
@@ -95,12 +95,12 @@ export default (opt: { [string]: any } = {}) => {
 
   return class MdEditor extends React.Component<Props> {
     render() {
-      const { value, onChange, ...rest } = this.props;
+      const { value, onChange, plugins, ...rest } = this.props;
       return (
         <div className="markdown-body">
           <Editor
             value={value}
-            plugins={plugins}
+            plugins={[...mdEditorPlugins, ...(plugins || [])]}
             onChange={onChange}
             {...rest}
           />


### PR DESCRIPTION
Was hoping to use this code (really impressive work!), but i have a few other plugins I want it to work with as well. I tried using the plugin instead of the whole editor, but i'm still interested in all of the rendering plugins that get loaded into the editor (instead of loading up all of the other dependencies in my project).

Just adding the ability to spread other plugins into the editor so that it works for my use case, though I think it's a pretty non-controversial change.