### PR TITLE
Fix plugin re-resolving during each update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,13 +94,18 @@ export default (opt: { [string]: any } = {}) => {
   };
 
   return class MdEditor extends React.Component<Props> {
+    constructor(props) {
+      super(props);
+      this.plugins = [...mdEditorPlugins, ...(this.props.plugins || [])];
+    }
+
     render() {
-      const { value, onChange, plugins, ...rest } = this.props;
+      const { value, onChange, ...rest } = this.props;
       return (
         <div className="markdown-body">
           <Editor
             value={value}
-            plugins={[...mdEditorPlugins, ...(plugins || [])]}
+            plugins={this.plugins}
             onChange={onChange}
             {...rest}
           />


### PR DESCRIPTION
Hi,

As discussed under [PR#29](https://github.com/Canner/slate-md-editor/pull/29), this should fix the plugin re-resolving problem:

```
Warning: A Slate <Editor> is re-resolving `props.plugins` or `props.schema` on each update, which leads to poor performance. This is often due to passing in a new `schema` or `plugins` prop with each render by declaring them inline in your render function. Do not do this!
```

that might cause performance issue. After this fix the demo runs a bit faster :) 

Best