### PR TITLE
Fix parent plugin override bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export default (opt: { [string]: any } = {}) => {
     }
 
     render() {
-      const { value, onChange, ...rest } = this.props;
+      const { value, onChange, plugins, ...rest } = this.props;
       return (
         <div className="markdown-body">
           <Editor


### PR DESCRIPTION
Hi @chilijung 

Actually I introduced a bug in the last PR... I didn't test the versions with actual plugins (I removed the plugin from the deconstructor but I didn't notice the ...rest syntax...)... sorry for the inconvenience :/

Best